### PR TITLE
feat/test : 모든 태그 카운트 기능 구현/테스트, 공유/개인 독후감 조회에 최신순으로 정렬하는 기능 구현/테스트 완료

### DIFF
--- a/src/main/java/com/book_everywhere/domain/review/ReviewRepository.java
+++ b/src/main/java/com/book_everywhere/domain/review/ReviewRepository.java
@@ -1,7 +1,5 @@
 package com.book_everywhere.domain.review;
 
-import com.book_everywhere.domain.book.Book;
-import com.book_everywhere.domain.user.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -15,23 +13,15 @@ import java.util.List;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
     //공유목록에서의 모든 독후감 조회
-    List<Review> findByIsPrivate(boolean isPrivate, Pageable pageable);
-
-    //특정 유저의 모든 독후감 조회
-    @Query("SELECT r FROM Review r WHERE r.book.id = :bookId AND r.book.user.socialId = :userId")
-    List<Review> findReviewsByUserAndBook(@Param("userId") Long userId, @Param("bookId") Long bookId);
+    List<Review> findByIsPrivateOrderByCreateAtDesc(boolean isPrivate, Pageable pageable);
 
     // 개인지도에서 핀을 눌렀을때 독후감이 모두 뜨는 기능
     // Entity 바뀐다면 수정 필요 -> 수정완료
-    @Query("SELECT review FROM Review review WHERE review.book.user.socialId = :socialId AND review.pin.id = :pinId")
+    @Query("SELECT review FROM Review review WHERE review.book.user.socialId = :socialId AND review.pin.id = :pinId ORDER BY review.createAt DESC")
     List<Review> mFindReviewUserMap(@Param("socialId") Long socialId, @Param("pinId") Long pinId);
 
-    //모든 공유리뷰 호출
-    @Query("SELECT review FROM Review review WHERE review.isPrivate = false")
-    List<Review> mFindAllPublicReviews();
-
     // socialId를 통한 모든 독후감 생성
-    @Query("SELECT r FROM Review r WHERE r.book.user.socialId = :userId")
+    @Query("SELECT r FROM Review r WHERE r.book.user.socialId = :userId ORDER BY r.createAt DESC")
     List<Review> mFindReviewsByUser(@Param("userId") Long userId);
     
   //독후감 삭제

--- a/src/main/java/com/book_everywhere/domain/tagged/TaggedRepository.java
+++ b/src/main/java/com/book_everywhere/domain/tagged/TaggedRepository.java
@@ -1,6 +1,7 @@
 package com.book_everywhere.domain.tagged;
 
 import com.book_everywhere.domain.pin.Pin;
+import com.book_everywhere.web.dto.tag.TagCountDto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -17,4 +18,8 @@ public interface TaggedRepository extends JpaRepository<Tagged,Long> {
 
     @Query("SELECT t FROM Tagged t WHERE t.tag.id = :tagId AND t.pin.id = :pinId")
     Tagged mFindTagged(@Param("tagId") Long tagId, @Param("pinId") Long pinId);
+
+    //pin에 대한 모든 태그 개수 새기
+    @Query("SELECT new com.book_everywhere.web.dto.tag.TagCountDto(t.tag.content, COUNT(t) AS count) FROM Tagged t GROUP BY t.tag.id ")
+    List<TagCountDto> mFindPinTaggedCount();
 }

--- a/src/main/java/com/book_everywhere/service/ReviewService.java
+++ b/src/main/java/com/book_everywhere/service/ReviewService.java
@@ -71,7 +71,7 @@ public class ReviewService {
     //공유 목록에서의 독후감 조회
     @Transactional(readOnly = true)
     public List<ReviewDto> 공유독후감조회(boolean isPrivate, Pageable pageable) {
-        List<Review> init = reviewRepository.findByIsPrivate(isPrivate, pageable);
+        List<Review> init = reviewRepository.findByIsPrivateOrderByCreateAtDesc(isPrivate, pageable);
         if(init.isEmpty()) {
             throw new EntityNotFoundException(CustomErrorCode.PIN_NOT_FOUND);
         }

--- a/src/main/java/com/book_everywhere/service/TagService.java
+++ b/src/main/java/com/book_everywhere/service/TagService.java
@@ -7,6 +7,7 @@ import com.book_everywhere.domain.tag.TagRepository;
 import com.book_everywhere.domain.tagged.Tagged;
 import com.book_everywhere.domain.tagged.TaggedRepository;
 import com.book_everywhere.web.dto.review.ReviewRespDto;
+import com.book_everywhere.web.dto.tag.TagCountDto;
 import com.book_everywhere.web.dto.tag.TagRespDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -47,6 +48,10 @@ public class TagService {
     public List<String> 모든태그조회() {
         List<Tag> tags = tagRepository.findAll();
         return tags.stream().map(Tag::getContent).toList();
+    }
+
+    public List<TagCountDto> 모든태그의개수조회() {
+        return taggedRepository.mFindPinTaggedCount();
     }
 
 }

--- a/src/main/java/com/book_everywhere/web/TagController.java
+++ b/src/main/java/com/book_everywhere/web/TagController.java
@@ -2,9 +2,11 @@ package com.book_everywhere.web;
 
 import com.book_everywhere.service.TagService;
 import com.book_everywhere.web.dto.CMRespDto;
+import com.book_everywhere.web.dto.tag.TagCountDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -16,7 +18,13 @@ public class TagController {
     private final TagService tagService;
     @GetMapping("/api/tags")
     public CMRespDto<?> findAllTag() {
-        List<String> 모든태그조회 = tagService.모든태그조회();
-        return new CMRespDto<>(HttpStatus.OK, 모든태그조회, "태그 조회 성공");
+        List<String> result = tagService.모든태그조회();
+        return new CMRespDto<>(HttpStatus.OK, result, "태그 조회 성공");
+    }
+
+    @GetMapping("/api/tags/count")
+    public CMRespDto<?> findTagCount() {
+        List<TagCountDto> result = tagService.모든태그의개수조회();
+        return new CMRespDto<>(HttpStatus.OK, result, "태그 개수 조회 성공");
     }
 }

--- a/src/main/java/com/book_everywhere/web/dto/tag/TagCountDto.java
+++ b/src/main/java/com/book_everywhere/web/dto/tag/TagCountDto.java
@@ -1,0 +1,11 @@
+package com.book_everywhere.web.dto.tag;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class TagCountDto {
+    private String content;
+    private Long count;
+}


### PR DESCRIPTION
모든 태그 개수 새기 기능이 추가되었습니다.
TagCountDto를 통해서 content, count를 프론트로 전달합니다.
PostMan을 통한 조회 예시
{
    "statusCode": "OK",
    "data": [
        {
            "content": "tag1",
            "count": 1
        },
        {
            "content": "tag2",
            "count": 1
        },
        {
            "content": "tag3",
            "count": 1
        }
    ],
    "message": "태그

ORDER BY createdAt을 통해 독후감 조회 기능을 최신순으로 정렬하도록 변경했습니다.
PostMan을 통한 조회 예시
{
    "statusCode": "OK",
    "data": [
        {
            "id": 3,
            "title": "titleInfo",
            "content": "content",
            "createdAt": "2024-02-26T16:25:07.901+00:00",
            "updatedAt": "2024-02-26T16:25:07.901+00:00"
        },
        {
            "id": 2,
            "title": "titleInfo",
            "content": "content",
            "createdAt": "2024-02-26T16:25:05.381+00:00",
            "updatedAt": "2024-02-26T16:25:05.381+00:00"
        },
        {
            "id": 1,
            "title": "titleInfo",
            "content": "content",
            "createdAt": "2024-02-26T16:25:04.087+00:00",
            "updatedAt": "2024-02-26T16:25:04.087+00:00"
        }
    ],
    "message": "전체 공유 독후감 조회"
}