### PR TITLE
feat: bookId에 따라 종속된 모든 review를 불러오는 기능

### DIFF
--- a/src/main/java/com/book_everywhere/domain/review/ReviewRepository.java
+++ b/src/main/java/com/book_everywhere/domain/review/ReviewRepository.java
@@ -23,8 +23,11 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     // socialId를 통한 모든 독후감 생성
     @Query("SELECT r FROM Review r WHERE r.book.user.socialId = :userId ORDER BY r.createAt DESC")
     List<Review> mFindReviewsByUser(@Param("userId") Long userId);
-    
-  //독후감 삭제
+
+    @Query("SELECT r FROM Review r WHERE r.book.id = :bookId ORDER BY r.createAt DESC")
+    List<Review> mFindReviewsByBook(@Param("bookId") Long bookId);
+
+    //독후감 삭제
     @Modifying
     @Query("DELETE FROM Review WHERE id = :reviewId")
     int mDeleteReview(@Param("reviewId") Long reviewId);

--- a/src/main/java/com/book_everywhere/service/PinService.java
+++ b/src/main/java/com/book_everywhere/service/PinService.java
@@ -50,8 +50,8 @@ public class PinService {
     }
 
     @Transactional(readOnly = true)
-    public List<PinDto> 나만의지도조회(@AuthenticationPrincipal OAuth2User oAuth2User) {
-        List<Pin> init = pinRepository.mUserMap((Long) oAuth2User.getAttributes().get("id"));
+    public List<PinDto> 나만의지도조회(Long userId) {
+        List<Pin> init = pinRepository.mUserMap(userId);
 
         List<PinDto> resultDto = init.stream()
                 .map(pin -> new PinDto(pin.getId(), pin.getPlaceId(), pin.getLatitude(), pin.getLongitude(), pin.getTitle(), pin.getAddress(), pin.getCreateAt()))

--- a/src/main/java/com/book_everywhere/service/ReviewService.java
+++ b/src/main/java/com/book_everywhere/service/ReviewService.java
@@ -57,6 +57,20 @@ public class ReviewService {
         return review.getId();
     }
 
+    //책에따른 모든 리뷰기능이 추가되었습니다.
+    @Transactional
+    public List<ReviewDto> 책에따른모든리뷰(Long bookId){
+        List<Review> init = reviewRepository.mFindReviewsByBook(bookId);
+        if(init.isEmpty()) {
+            throw new EntityNotFoundException(CustomErrorCode.PIN_NOT_FOUND);
+        }
+
+        List<ReviewDto> resultDto = init.stream()
+                .map(review -> new ReviewDto(review.getId(), review.getTitle(), review.getContent(), review.isPrivate(), review.getUpdateAt(), review.getCreateAt()))
+                .toList();
+
+        return resultDto;
+    }
 
     //수정
     @Transactional

--- a/src/main/java/com/book_everywhere/service/TagService.java
+++ b/src/main/java/com/book_everywhere/service/TagService.java
@@ -54,7 +54,7 @@ public class TagService {
         return tags.stream().map(Tag::getContent).toList();
     }
 
-    public List<Page<TagCountDto>>  핀의5개태그조회()  {
+    public List<Page<TagCountDto>> 핀의5개태그조회()  {
         List<Pin> pins = pinRepository.mFindAllPin();
         List<Page<TagCountDto>> tagFiveList = new ArrayList<>();
         for(Pin pin : pins){

--- a/src/main/java/com/book_everywhere/web/BookController.java
+++ b/src/main/java/com/book_everywhere/web/BookController.java
@@ -48,7 +48,8 @@ public class BookController {
         return new CMRespDto<>(HttpStatus.OK, result, "단일 책 조회 완료");
     }
 
-    @GetMapping("/api/books")
+    //유저 책 조회
+    @GetMapping("/mypage/{socialId}")
     public CMRespDto<?> findOneBookWithUser(@RequestParam Long socialId) {
         List<BookDto> result = bookService.findAllBookOneUser(socialId);
         return new CMRespDto<>(HttpStatus.OK, result, "유저의 책 조회 완료");

--- a/src/main/java/com/book_everywhere/web/PinController.java
+++ b/src/main/java/com/book_everywhere/web/PinController.java
@@ -27,31 +27,26 @@ public class PinController {
     private final ReviewService reviewService;
 
 
-    @GetMapping("/api/pin")
+    @GetMapping("/map")
     public CMRespDto<?> allPin() {
         List<PinDto> result = pinService.전체지도조회();
-        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication != null) {
-            System.out.println("Authentication details: " + authentication.toString());
-            System.out.println("Authorities: " + authentication.getAuthorities().toString());
-        }
-
         return new CMRespDto<>(HttpStatus.OK, result,"전체 지도 조회 성공!");
     }
 
     //핀을 눌렀을때 핀에 해당하는 독후감 정보 조회
-    @GetMapping("/api/pin/{id}")
-    public CMRespDto<?> pinDetails(@PathVariable Long id, @AuthenticationPrincipal OAuth2User oAuth2User) {
-        List<ReviewDto> result = reviewService.단일핀독후감조회(id, oAuth2User);
-        return new CMRespDto<>(HttpStatus.OK, result,"핀 및 종속 독후감 조회 성공!");
+    @GetMapping("/api/pin/{pinId}")
+    public CMRespDto<?> pinDetails(@PathVariable Long pinId, @AuthenticationPrincipal OAuth2User oAuth2User) {
+        List<ReviewDto> result = reviewService.단일핀독후감조회(pinId, oAuth2User);
+        return new CMRespDto<>(HttpStatus.OK, result,"단일 핀 종속 독후감 조회 성공!");
     }
 
     //나만의 지도 기능
-    @GetMapping("/api/pin/user")
-    public CMRespDto<?> userMap(@AuthenticationPrincipal OAuth2User oAuth2User) {
-        List<PinDto> result = pinService.나만의지도조회(oAuth2User);
-        return new CMRespDto<>(HttpStatus.OK, result,"핀 및 종속 독후감 조회 성공!");
+    @GetMapping("/map/{userId}")
+    public CMRespDto<?> userMap(@PathVariable Long userId) {
+        List<PinDto> result = pinService.나만의지도조회(userId);
+        return new CMRespDto<>(HttpStatus.OK, result,"유저 독후감 조회 성공!");
     }
+
     //태그String에 대한 pin 추출
     @GetMapping("/api/pin/tag/{content}")
     public CMRespDto<?> taggedPin(@PathVariable String content) {
@@ -59,7 +54,7 @@ public class PinController {
         return new CMRespDto<>(HttpStatus.OK, result,"태그 조회 성공!"); // 이 부분 논의
     }
 
-    @GetMapping("/api/user/review")
+    @GetMapping("/mypage/아직미정")
     public CMRespDto<?> userReview(@AuthenticationPrincipal OAuth2User oAuth2User) {
         List<ReviewDto> result = reviewService.유저모든독후감조회(oAuth2User);
         return new CMRespDto<>(HttpStatus.OK, result,"모든 독후감 조회 성공!");

--- a/src/main/java/com/book_everywhere/web/ReviewController.java
+++ b/src/main/java/com/book_everywhere/web/ReviewController.java
@@ -1,6 +1,7 @@
 package com.book_everywhere.web;
 
 
+import com.book_everywhere.domain.review.Review;
 import com.book_everywhere.service.*;
 import com.book_everywhere.web.dto.CMRespDto;
 import com.book_everywhere.web.dto.review.ReviewDto;
@@ -31,19 +32,19 @@ public class ReviewController {
      * 최초등록시 visit 등록기능
      * review 등록 기능
      */
-    @PostMapping("/api/review")
+    @PostMapping("/write")
     public CMRespDto<?> addReview(@RequestBody ReviewRespDto reviewRespDto) {
-        pinService.핀생성(reviewRespDto); //null처리 완료
-        bookService.책생성하기(reviewRespDto);// null처리 완료
-        tagService.태그등록(reviewRespDto); // null처리 완료
-        visitService.독후감쓰기전방문등록(reviewRespDto); // null처리 완료
+        pinService.핀생성(reviewRespDto);
+        bookService.책생성하기(reviewRespDto);
+        tagService.태그등록(reviewRespDto);
+        visitService.독후감쓰기전방문등록(reviewRespDto);
         reviewService.독후감생성하기(reviewRespDto);
         return new CMRespDto<>(HttpStatus.OK, null, "독후감 추가 완료");
     }
 
     //조회
     //공개 독후감 조회
-    @GetMapping("/api/public/review")
+    @GetMapping("/reviews")
     public CMRespDto<?> publicReviews(@RequestParam int page,
                                 @RequestParam int size,
                                 @RequestParam boolean isPrivate) {
@@ -51,6 +52,13 @@ public class ReviewController {
         List<ReviewDto> result = reviewService.공유독후감조회(isPrivate, pageable);
         return new CMRespDto<>(HttpStatus.OK, result, "전체 공유 독후감 조회");
     }
+
+    @GetMapping("/detail/{bookId}")
+    public CMRespDto<?> bookReviews(@PathVariable Long bookId) {
+        List<ReviewDto> result = reviewService.책에따른모든리뷰(bookId);
+        return new CMRespDto<>(HttpStatus.OK, result, "책에 따른 전체 독후감 조회");
+    }
+
 
     //수정
     @PutMapping("/api/review/{id}")


### PR DESCRIPTION
## 추가적으로 front와 url mapping을 완료하였습니다

/reviews:모든기록 :o:  [설정완료]
- :pushpin: ReviewController<publicReviews>
- GET 전체 공유 독후감 조회

/mypage/{socialId}: socialId를가진 유저의 내 서재 -> 모든 책
- :pushpin: BookController<findOneBookWithUser>
- GET user의 모든 책 조회 Return  bookDto

/detail/{bookId}: :o: 책에대한 모든 독후감 -> 단일 독후감은 모달처리 즉 책에따른 모든 독후감을 전달할 것
-:pushpin: ReviewConroller<bookReviews>
- GET 책에따른 모든 독후감 Return List<ReviewDto>


/write: :o: 기록하기
- :pushpin: ReviewController <addReview>
- Post 리뷰 기록하기
- 전달 DTO -> ReviewRespDto

/edit/{id}: id 인 게시글 수정

/map: 공유지도 :o:  [설정 완료]
- :pushpin: PinController<allPin>
- Get 모든 핀 데이터 전송
- 상호작용 :white_check_mark:  RestApi
  - [한번에 담기 힘들어 따로 요청 필요] Get /api/tags/top ->  모든핀의 상위 5개 태그 조회

/map/{socailid}: :o: [설정 완료] socailid 유저의 개인지도
- :pushpin:  PinController <userMap>
- GET 유저에 따른 모든 핀
- 상호작용 :white_check_mark:  RestApi
  - [핀 클릭시] GET /api/pin/{pinId} -> 핀을 눌렀을때 핀에 해당하는 독후감 조회