### PR TITLE
feat : 독후감 조회 기능 세분화/ 프론트 요구 사항에 따른 데이터 코드 추가

### DIFF
--- a/src/main/java/com/book_everywhere/domain/review/ReviewRepository.java
+++ b/src/main/java/com/book_everywhere/domain/review/ReviewRepository.java
@@ -12,8 +12,11 @@ import java.util.List;
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 
-    //공유목록에서의 모든 독후감 조회
+    //공유 목록에서의 독후감 페이지 조회
     List<Review> findByIsPrivateOrderByCreateAtDesc(boolean isPrivate, Pageable pageable);
+
+    //공유 목록에서의 모든 독후감 조회
+    List<Review> findByIsPrivateOrderByCreateAtDesc(boolean isPrivate);
 
     // 개인지도에서 핀을 눌렀을때 독후감이 모두 뜨는 기능
     // Entity 바뀐다면 수정 필요 -> 수정완료

--- a/src/main/java/com/book_everywhere/domain/tagged/TaggedRepository.java
+++ b/src/main/java/com/book_everywhere/domain/tagged/TaggedRepository.java
@@ -29,4 +29,7 @@ public interface TaggedRepository extends JpaRepository<Tagged,Long> {
     @Modifying
     @Query("DELETE FROM Tagged WHERE id = :taggedId")
     int mDeleteTagged(@Param("taggedId") Long taggedId);
+
+    //핀에 해당하는 모든 태그 조회하기 - WebDataService에서 사용하는 용도
+     List<Tagged> findAllByPinId(Long pinId);
 }

--- a/src/main/java/com/book_everywhere/service/ReviewService.java
+++ b/src/main/java/com/book_everywhere/service/ReviewService.java
@@ -141,4 +141,29 @@ public class ReviewService {
                         review.getUpdateAt())).toList();
     }
 
+    public List<ReviewDto> 공유독후감10개조회(Pageable pageable) {
+        List<Review> init = reviewRepository.findByIsPrivateOrderByCreateAtDesc(false, pageable);
+        return init.stream().map(review ->
+                new ReviewDto(
+                        review.getId(),
+                        review.getWriter(),
+                        review.getTitle(),
+                        review.getContent(),
+                        review.isPrivate(),
+                        review.getCreateAt(),
+                        review.getUpdateAt())).toList();
+    }
+
+    public List<ReviewDto> 모든공유독후감조회() {
+        List<Review> init = reviewRepository.findByIsPrivateOrderByCreateAtDesc(false);
+        return init.stream().map(review ->
+                new ReviewDto(
+                        review.getId(),
+                        review.getWriter(),
+                        review.getTitle(),
+                        review.getContent(),
+                        review.isPrivate(),
+                        review.getCreateAt(),
+                        review.getUpdateAt())).toList();
+    }
 }

--- a/src/main/java/com/book_everywhere/service/WebDataService.java
+++ b/src/main/java/com/book_everywhere/service/WebDataService.java
@@ -1,0 +1,94 @@
+package com.book_everywhere.service;
+
+import com.book_everywhere.domain.book.Book;
+import com.book_everywhere.domain.book.BookRepository;
+import com.book_everywhere.domain.pin.Pin;
+import com.book_everywhere.domain.pin.PinRepository;
+import com.book_everywhere.domain.review.Review;
+import com.book_everywhere.domain.review.ReviewRepository;
+import com.book_everywhere.domain.tagged.Tagged;
+import com.book_everywhere.domain.tagged.TaggedRepository;
+import com.book_everywhere.web.dto.book.BookRespDto;
+import com.book_everywhere.web.dto.exception.customs.CustomErrorCode;
+import com.book_everywhere.web.dto.exception.customs.EntityNotFoundException;
+import com.book_everywhere.web.dto.pin.PinRespDto;
+import com.book_everywhere.web.dto.review.ReviewRespDto;
+import com.book_everywhere.web.dto.tag.TagRespDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+//프론트 단 요청에 의해 만들어진 서비스 입니다. 이후에 삭제될 예정입니다.
+@Service
+@RequiredArgsConstructor
+public class WebDataService {
+
+    private final ReviewRepository reviewRepository;
+    private final PinRepository pinRepository;
+    private final BookRepository bookRepository;
+    private final TaggedRepository taggedRepository;
+    private final TagService tagService;
+
+
+
+    public List<ReviewRespDto> 모든공유데이터가져오기() {
+        List<Review> reviews = reviewRepository.findByIsPrivateOrderByCreateAtDesc(false);
+
+        List<ReviewRespDto> result = reviews.stream().map(review ->
+        {
+            Pin pin = pinRepository.mFindByPinId(review.getPin().getId());
+            PinRespDto pinRespDto = new PinRespDto(
+                    pin.getTitle(),
+                    pin.getPlaceId(),
+                    pin.getLatitude(),
+                    pin.getLongitude(),
+                    pin.getAddress(),
+                    review.isPrivate(),
+                    pin.getUrl());
+            Book book = bookRepository.findById(review.getBook().getId())
+                    .orElseThrow(() -> new EntityNotFoundException(CustomErrorCode.BOOK_NOT_FOUND));
+            BookRespDto bookRespDto = new BookRespDto(
+                    book.getIsbn(),
+                    book.getTitle(),
+                    book.getCoverImageUrl(),
+                    book.isComplete()
+            );
+            List<Tagged> taggedList = taggedRepository.findAllByPinId(pin.getId());
+            List<String> tags = tagService.모든태그조회();
+            List<TagRespDto> tagRespDtoList = taggedList.stream().map(tagged ->
+            {
+                boolean isSelected = false;
+
+                for (String tag : tags) {
+                    if (tag.equals(tagged.getTag().getContent())) {
+                        isSelected = true;
+                        break;
+                    }
+                }
+
+                return new TagRespDto(
+                        tagged.getTag().getContent(),
+                        isSelected
+                );
+            }).toList();
+
+            return new ReviewRespDto(
+                    book.getUser().getSocialId(),
+                    review.getWriter(),
+                    review.getTitle(),
+                    review.isPrivate(),
+                    pinRespDto,
+                    bookRespDto,
+                    tagRespDtoList,
+                    review.getContent()
+            );
+        }).toList();
+        return result;
+    }
+
+    //태그 조회 테스트용
+    public List<Tagged> findAllTaggedList(Long pinId) {
+        return taggedRepository.findAllByPinId(pinId);
+    }
+}

--- a/src/main/java/com/book_everywhere/web/ReviewController.java
+++ b/src/main/java/com/book_everywhere/web/ReviewController.java
@@ -47,7 +47,7 @@ public class ReviewController {
     @GetMapping("/api/reviews")
     public CMRespDto<?> publicReviews(){
         List<ReviewDto> result = reviewService.모든독후감조회();
-        return new CMRespDto<>(HttpStatus.OK, result, "전체 공유 독후감 조회");
+        return new CMRespDto<>(HttpStatus.OK, result, "전체 독후감 조회");
     }
 
     @GetMapping("/api/detail/{bookId}")
@@ -69,6 +69,19 @@ public class ReviewController {
     public CMRespDto<?> updateReview(@PathVariable Long reviewId, ReviewDto reviewDto) {
 //        reviewService.독후감업데이트(reviewId, reviewDto);
         return new CMRespDto<>(HttpStatus.OK, null, "독후감 수정 완료");
+    }
+
+    @GetMapping("/api/review/public")
+    public CMRespDto<?> findPublicReviews() {
+        List<ReviewDto> result = reviewService.모든공유독후감조회();
+        return new CMRespDto<>(HttpStatus.OK, result, "모든 공유 독후감 조회 완료");
+    }
+
+    //ex) 파람 page=2&size=10&sort=createdAt,desc
+    @GetMapping("/api/review/public")
+    public CMRespDto<?> findPublicReviewsWithPage(Pageable pageable) {
+        List<ReviewDto> result = reviewService.공유독후감10개조회(pageable);
+        return new CMRespDto<>(HttpStatus.OK, result, "공유 독후감 페이지 조회 완료");
     }
 
 }

--- a/src/main/java/com/book_everywhere/web/WebDataController.java
+++ b/src/main/java/com/book_everywhere/web/WebDataController.java
@@ -1,0 +1,34 @@
+package com.book_everywhere.web;
+
+import com.book_everywhere.domain.tagged.Tagged;
+import com.book_everywhere.service.WebDataService;
+import com.book_everywhere.web.dto.CMRespDto;
+import com.book_everywhere.web.dto.review.ReviewRespDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class WebDataController {
+
+    private final WebDataService webDataService;
+
+    @GetMapping("/api/data/all")
+    public CMRespDto<?> findAllData() {
+        List<ReviewRespDto> result = webDataService.모든공유데이터가져오기();
+        return new CMRespDto<>(HttpStatus.OK, result,"모든 데이터 조회 성공");
+    }
+
+    @GetMapping("/api/tags/pinId")
+    public CMRespDto<?> findTagsInPin(@PathVariable Long pinId) {
+        List<Tagged> result = webDataService.findAllTaggedList(pinId);
+        return new CMRespDto<>(HttpStatus.OK, result, "핀에 대한 모든 태그 조회 성공");
+    }
+}


### PR DESCRIPTION
독후감 조회 기능
전체 독후감 조회
공유 독후감 조회
공유 독후감 페이지 조회
3가지로 세분화하였습니다

프론트 요구 사항에 따른 데이터 코드를 추가합니다
WebDataService
WebDataController

데이터 조회는 
ReviewRespDto와 같은 스펙으로 조회됩니다.

// test를 위한 코드 추가
핀을 이용한 tagged 찾기 기능을 추가합니다.