### PR TITLE
feat/chore : category 객체 추가, 서비스, 컨트롤러 기능 추가 완료/ api 스펙 변경에 따른 dataService 변경 완료

### DIFF
--- a/src/main/java/com/book_everywhere/domain/category/Category.java
+++ b/src/main/java/com/book_everywhere/domain/category/Category.java
@@ -1,0 +1,27 @@
+package com.book_everywhere.domain.category;
+
+import com.book_everywhere.domain.tag.Tag;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToMany(mappedBy = "category")
+    private List<Tag> tag;
+
+    private String name;
+}

--- a/src/main/java/com/book_everywhere/domain/category/CategoryRepository.java
+++ b/src/main/java/com/book_everywhere/domain/category/CategoryRepository.java
@@ -1,0 +1,6 @@
+package com.book_everywhere.domain.category;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+}

--- a/src/main/java/com/book_everywhere/domain/tag/Tag.java
+++ b/src/main/java/com/book_everywhere/domain/tag/Tag.java
@@ -25,7 +25,7 @@ public class Tag {
     private List<Tagged> tags;
 
     @ManyToOne
-    @JoinColumn(name = "tagId")
+    @JoinColumn(name = "categoryId")
     private Category category;
 
     @Column(nullable = false, unique = true)

--- a/src/main/java/com/book_everywhere/domain/tag/Tag.java
+++ b/src/main/java/com/book_everywhere/domain/tag/Tag.java
@@ -1,14 +1,9 @@
 package com.book_everywhere.domain.tag;
 
 import com.book_everywhere.domain.book.Book;
+import com.book_everywhere.domain.category.Category;
 import com.book_everywhere.domain.tagged.Tagged;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToMany;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,6 +24,11 @@ public class Tag {
     @OneToMany(mappedBy = "tag",cascade = CascadeType.ALL)
     private List<Tagged> tags;
 
+    @ManyToOne
+    @JoinColumn(name = "tagId")
+    private Category category;
+
     @Column(nullable = false, unique = true)
     private String content;
+
 }

--- a/src/main/java/com/book_everywhere/domain/tagged/TaggedRepository.java
+++ b/src/main/java/com/book_everywhere/domain/tagged/TaggedRepository.java
@@ -25,6 +25,9 @@ public interface TaggedRepository extends JpaRepository<Tagged,Long> {
 // Tagged 엔티티의 Repository 인터페이스 내에 메소드 추가
     Page<Tagged> findByPinIdOrderByCountDesc(Long pinId, Pageable pageable);
 
+    @Query("SELECT t FROM Tagged t WHERE t.pin.id = :pinId ORDER BY t.count DESC")
+    List<Tagged> mFindPinWithTagCount(@Param("pinId") Long pinId, Pageable pageable);
+
 
     @Modifying
     @Query("DELETE FROM Tagged WHERE id = :taggedId")

--- a/src/main/java/com/book_everywhere/service/DataService.java
+++ b/src/main/java/com/book_everywhere/service/DataService.java
@@ -2,6 +2,7 @@ package com.book_everywhere.service;
 
 import com.book_everywhere.domain.book.Book;
 import com.book_everywhere.domain.book.BookRepository;
+import com.book_everywhere.domain.category.CategoryRepository;
 import com.book_everywhere.domain.pin.Pin;
 import com.book_everywhere.domain.pin.PinRepository;
 import com.book_everywhere.domain.review.Review;
@@ -22,7 +23,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 
 //프론트 단 요청에 의해 만들어진 서비스 입니다. 이후에 삭제될 예정입니다.
@@ -65,22 +65,15 @@ public class DataService {
                     book.getAuthor()
             );
             List<Tagged> taggedList = taggedRepository.findAllByPinId(pin.getId());
-            List<String> tags = tagRepository.findAll().stream().map(Tag::getContent).toList();
-            List<TagRespDto> tagRespDtoList = taggedList.stream().map(tagged ->
-            {
-                boolean isSelected = false;
-
-                for (String tag : tags) {
-                    if (tag.equals(tagged.getTag().getContent())) {
-                        isSelected = true;
-                        break;
+            List<Tag> tagObjects = tagRepository.findAll();
+            List<TagRespDto> tagRespDtoList = tagObjects.stream().map(tag -> {
+                String name = tag.getCategory().getName();
+                for (Tagged tagged : taggedList) {
+                    if (tag.getContent().equals(tagged.getTag().getContent())) {
+                        return new TagRespDto(tag.getContent(), true, name);
                     }
                 }
-
-                return new TagRespDto(
-                        tagged.getTag().getContent(),
-                        isSelected
-                );
+                return new TagRespDto(tag.getContent(), false, name);
             }).toList();
 
             return new AllDataDto(
@@ -129,14 +122,15 @@ public class DataService {
                     book.getAuthor()
             );
             List<Tagged> taggedList = taggedRepository.findAllByPinId(pin.getId());
-            List<String> tags = tagRepository.findAll().stream().map(Tag::getContent).toList();
-            List<TagRespDto> tagRespDtoList = tags.stream().map(tag -> {
+            List<Tag> tagObjects = tagRepository.findAll();
+            List<TagRespDto> tagRespDtoList = tagObjects.stream().map(tag -> {
+                String name = tag.getCategory().getName();
                 for (Tagged tagged : taggedList) {
-                    if (tag.equals(tagged.getTag().getContent())) {
-                        return new TagRespDto(tag, true);
+                    if (tag.getContent().equals(tagged.getTag().getContent())) {
+                        return new TagRespDto(tag.getContent(), true, name);
                     }
                 }
-                return new TagRespDto(tag, false);
+                return new TagRespDto(tag.getContent(), false, name);
             }).toList();
 
 

--- a/src/main/java/com/book_everywhere/service/DataService.java
+++ b/src/main/java/com/book_everywhere/service/DataService.java
@@ -2,7 +2,6 @@ package com.book_everywhere.service;
 
 import com.book_everywhere.domain.book.Book;
 import com.book_everywhere.domain.book.BookRepository;
-import com.book_everywhere.domain.category.CategoryRepository;
 import com.book_everywhere.domain.pin.Pin;
 import com.book_everywhere.domain.pin.PinRepository;
 import com.book_everywhere.domain.review.Review;
@@ -40,7 +39,7 @@ public class DataService {
 
 
 
-    public List<AllDataDto> 모든공유또는개인데이터가져오기(boolean isPrivate) {
+    public List<AllDataDto> 모든공유또는개인데이터조회(boolean isPrivate) {
         List<Review> reviews = reviewRepository.findByIsPrivateOrderByCreateAtDesc(isPrivate);
 
         return reviews.stream().map(review ->

--- a/src/main/java/com/book_everywhere/service/PinService.java
+++ b/src/main/java/com/book_everywhere/service/PinService.java
@@ -2,15 +2,17 @@ package com.book_everywhere.service;
 
 import com.book_everywhere.domain.pin.Pin;
 import com.book_everywhere.domain.pin.PinRepository;
+import com.book_everywhere.domain.tagged.Tagged;
 import com.book_everywhere.domain.tagged.TaggedRepository;
 import com.book_everywhere.web.dto.exception.customs.CustomErrorCode;
 import com.book_everywhere.web.dto.exception.customs.EntityNotFoundException;
 import com.book_everywhere.web.dto.pin.PinDto;
 import com.book_everywhere.web.dto.pin.PinRespDto;
+import com.book_everywhere.web.dto.pin.PinWithTagCountRespDto;
 import com.book_everywhere.web.dto.review.ReviewRespDto;
+import com.book_everywhere.web.dto.tag.TagCountRespDto;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -73,5 +75,30 @@ public class PinService {
                 .toList();
 
         return resultDto;
+    }
+
+    @Transactional(readOnly = true)
+    public List<PinWithTagCountRespDto> 핀의상위5개태그개수와함께조회() {
+        List<Pin> pins = pinRepository.findAll();
+        return pins.stream().map(pin -> {
+            PageRequest pageRequest = PageRequest.of(0, 5);
+            List<Tagged> taggeds = taggedRepository.mFindPinWithTagCount(pin.getId(), pageRequest);
+            List<TagCountRespDto> tagCountRespDtos = taggeds.stream()
+                    .map(tagged -> new TagCountRespDto(
+                            tagged.getTag().getContent(),
+                            tagged.getCount())).toList();
+
+            return new PinWithTagCountRespDto(
+                    pin.getId(),
+                    pin.getPlaceId(),
+                    pin.getLatitude(),
+                    pin.getLongitude(),
+                    pin.getTitle(),
+                    pin.getAddress(),
+                    pin.getUrl(),
+                    pin.getCreateAt(),
+                    tagCountRespDtos
+            );
+        }).toList();
     }
 }

--- a/src/main/java/com/book_everywhere/web/DataController.java
+++ b/src/main/java/com/book_everywhere/web/DataController.java
@@ -21,7 +21,7 @@ public class DataController {
 
     @GetMapping("/api/data/all")
     public CMRespDto<?> findAllData(@RequestParam Boolean isPrivate) {
-        List<AllDataDto> result = dataService.모든공유또는개인데이터가져오기(isPrivate);
+        List<AllDataDto> result = dataService.모든공유또는개인데이터조회(isPrivate);
         return new CMRespDto<>(HttpStatus.OK, result,"모든 데이터 조회 성공");
     }
 

--- a/src/main/java/com/book_everywhere/web/PinController.java
+++ b/src/main/java/com/book_everywhere/web/PinController.java
@@ -6,6 +6,7 @@ import com.book_everywhere.service.PinService;
 import com.book_everywhere.service.ReviewService;
 import com.book_everywhere.web.dto.CMRespDto;
 import com.book_everywhere.web.dto.pin.PinDto;
+import com.book_everywhere.web.dto.pin.PinWithTagCountRespDto;
 import com.book_everywhere.web.dto.review.ReviewDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -31,6 +32,12 @@ public class PinController {
     public CMRespDto<?> allPin() {
         List<PinDto> result = pinService.전체지도조회();
         return new CMRespDto<>(HttpStatus.OK, result,"전체 지도 조회 성공!");
+    }
+
+    @GetMapping("/api/map/tag/count")
+    public CMRespDto<?> allPinWithTagCount() {
+        List<PinWithTagCountRespDto> result = pinService.핀의상위5개태그개수와함께조회();
+        return new CMRespDto<>(HttpStatus.OK, result, "전체 지도 상위 5개 태그와 함께 조회 성공");
     }
 
     //핀을 눌렀을때 핀에 해당하는 독후감 정보 조회

--- a/src/main/java/com/book_everywhere/web/dto/pin/PinWithTagCountRespDto.java
+++ b/src/main/java/com/book_everywhere/web/dto/pin/PinWithTagCountRespDto.java
@@ -1,0 +1,23 @@
+package com.book_everywhere.web.dto.pin;
+
+import com.book_everywhere.web.dto.tag.TagCountRespDto;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.sql.Timestamp;
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class PinWithTagCountRespDto {
+    private Long id;
+    private double placeId;
+    private double latitude;
+    private double longitude;
+    //개인설정이름
+    private String title;
+    private String address;
+    private String url;
+    private Timestamp createAt;
+    private List<TagCountRespDto> tagCountRespDtos;
+}

--- a/src/main/java/com/book_everywhere/web/dto/tag/TagCountRespDto.java
+++ b/src/main/java/com/book_everywhere/web/dto/tag/TagCountRespDto.java
@@ -1,0 +1,11 @@
+package com.book_everywhere.web.dto.tag;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class TagCountRespDto {
+    private String content;
+    private int count;
+}

--- a/src/main/java/com/book_everywhere/web/dto/tag/TagRespDto.java
+++ b/src/main/java/com/book_everywhere/web/dto/tag/TagRespDto.java
@@ -9,4 +9,5 @@ import lombok.Data;
 public class TagRespDto {
     private String content;
     private boolean isSelected; // tagged 컬럼에 사용됨
+    private String category;
 }


### PR DESCRIPTION
category 테이블을 추가했습니다
column : id, name

DataService에 category 조회가 추가되었습니다.
모든 핀의 상위 5개 태그 개수와 함께 조회 하는 기능이 구현되었습니다.

PinWithTagCountRespDto가 추가되었습니다.
TagCountRespDto가 추가되었습니다.
PinController에 /api/map/tag/count 가 추가되었습니다.
pinService에 핀의상위5개태그개수와함께조회 매소드가추가되었습니다.
TaggedRepository에 mFindPinWithTagCount 매소드가추가되었습니다.

프론트 단에서 기록하기 페이지의 태그 부분에 대해서 새롭게 만들어 주시면 테스트를 진행할 예정입니다.