### PR TITLE
fix/refactor : 삭제 메서드에서 발생하는 오류들 해결, 각 검증 메서드의 null 분기처리 추가, DataService 태그 조회 변경

### DIFF
--- a/src/main/java/com/book_everywhere/domain/pin/Pin.java
+++ b/src/main/java/com/book_everywhere/domain/pin/Pin.java
@@ -25,7 +25,7 @@ public class Pin {
     private Long id;
 
     @Builder.Default
-    @OneToMany(mappedBy = "pin")
+    @OneToMany(mappedBy = "pin", cascade = CascadeType.ALL)
     private List<Visit> visits = new ArrayList<>();
 
     @Builder.Default
@@ -33,7 +33,7 @@ public class Pin {
     private List<Review> reviews = new ArrayList<>();
 
     @Builder.Default
-    @OneToMany(mappedBy = "pin")
+    @OneToMany(mappedBy = "pin", cascade = CascadeType.ALL)
     private List<Tagged> tags = new ArrayList<>();
 
     @Column(nullable = false)

--- a/src/main/java/com/book_everywhere/domain/tagged/TaggedRepository.java
+++ b/src/main/java/com/book_everywhere/domain/tagged/TaggedRepository.java
@@ -34,4 +34,7 @@ public interface TaggedRepository extends JpaRepository<Tagged,Long> {
 
     //핀에 해당하는 모든 태그 조회하기 - WebDataService에서 사용하는 용도
      List<Tagged> findAllByPinId(Long pinId);
+
+     @Query("SELECT t FROM Tagged t JOIN t.pin.visits v WHERE t.pin.id = :pinId AND v.user.socialId = :socialId")
+     List<Tagged> mFindAllByPinAndUser(@Param("pinId") Long pinId, @Param("socialId") Long socialId);
 }

--- a/src/main/java/com/book_everywhere/service/DataService.java
+++ b/src/main/java/com/book_everywhere/service/DataService.java
@@ -96,8 +96,8 @@ public class DataService {
     }
 
 
-    public List<AllDataDto> 유저독후감조회(Long userId) {
-        List<Review> reviews = reviewRepository.mFindReviewsByUser(userId);
+    public List<AllDataDto> 유저독후감조회(Long socialId) {
+        List<Review> reviews = reviewRepository.mFindReviewsByUser(socialId);
 
         return reviews.stream().map(review ->
         {
@@ -120,7 +120,7 @@ public class DataService {
                     book.isComplete(),
                     book.getAuthor()
             );
-            List<Tagged> taggedList = taggedRepository.findAllByPinId(pin.getId());
+            List<Tagged> taggedList = taggedRepository.mFindAllByPinAndUser(pin.getId(),socialId);
             List<Tag> tagObjects = tagRepository.findAll();
             List<TagRespDto> tagRespDtoList = tagObjects.stream().map(tag -> {
                 String name = tag.getCategory().getName();
@@ -146,6 +146,13 @@ public class DataService {
                     review.getCreateAt()
             );
         }).toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<TagRespDto> mFindAllByPinAndReview테스트(Long pinId, Long socialId) {
+        List<Tagged> init = taggedRepository.mFindAllByPinAndUser(pinId, socialId);
+
+        return init.stream().map(tagged -> new TagRespDto(tagged.getTag().getContent(), false, tagged.getTag().getCategory().getName())).toList();
     }
 
 

--- a/src/main/java/com/book_everywhere/service/ReviewService.java
+++ b/src/main/java/com/book_everywhere/service/ReviewService.java
@@ -164,6 +164,9 @@ public class ReviewService {
     @Transactional
     public void 유저독후감개수검증후책삭제(Long socialId, String title) {
         Book book = bookRepository.mFindBookByUserIdAndTitle(socialId, title);
+        if(book == null) {
+            throw new EntityNotFoundException(CustomErrorCode.BOOK_NOT_FOUND);
+        }
         List<Review> reviews = reviewRepository.mFindReviewsByBook(book.getId());
         if(reviews.isEmpty()) {
             bookRepository.delete(book);
@@ -173,6 +176,9 @@ public class ReviewService {
     @Transactional
     public void 독후감개수검증후핀삭제(String address) {
         Pin pin = pinRepository.mFindPinByAddress(address);
+        if(pin == null) {
+            throw new EntityNotFoundException(CustomErrorCode.PIN_NOT_FOUND);
+        }
         List<Review> reviews = reviewRepository.mFindReviewsByPin(pin.getId());
         if(reviews.isEmpty()) {
             pinRepository.delete(pin);

--- a/src/main/java/com/book_everywhere/web/DataController.java
+++ b/src/main/java/com/book_everywhere/web/DataController.java
@@ -4,6 +4,7 @@ import com.book_everywhere.domain.tagged.Tagged;
 import com.book_everywhere.service.DataService;
 import com.book_everywhere.web.dto.AllDataDto;
 import com.book_everywhere.web.dto.CMRespDto;
+import com.book_everywhere.web.dto.tag.TagRespDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/book_everywhere/web/ReviewController.java
+++ b/src/main/java/com/book_everywhere/web/ReviewController.java
@@ -78,6 +78,7 @@ public class ReviewController {
         reviewService.등록또는수정전예외처리(reviewRespDto);
         pinService.핀생성(reviewRespDto);
         bookService.책생성(reviewRespDto);
+        tagService.태그검증(reviewRespDto.getSocialId(), prevAddress);
         tagService.태그등록또는수정(reviewRespDto);
         visitService.독후감쓰기전방문등록또는수정(reviewRespDto);
         reviewService.독후감수정(reviewId, reviewRespDto);
@@ -97,11 +98,11 @@ public class ReviewController {
                                      @RequestParam Long socialId,
                                      @RequestParam String bookTitle,
                                      @RequestParam String address,
-                                     @RequestParam List<String> tags) {
+                                     @RequestParam(required = false) List<String> tags) {
         reviewService.독후감삭제(reviewId);
+        tagService.태그삭제(tags, address);
         reviewService.유저독후감개수검증후책삭제(socialId, bookTitle);
         reviewService.독후감개수검증후핀삭제(address);
-        tagService.태그삭제(tags, address);
         return new CMRespDto<>(HttpStatus.OK, null, "독후감 삭제 완료");
     }
 }

--- a/src/main/java/com/book_everywhere/web/TagController.java
+++ b/src/main/java/com/book_everywhere/web/TagController.java
@@ -28,4 +28,5 @@ public class TagController {
         List<Page<TaggedDto>> result = tagService.핀의5개태그조회();
         return new CMRespDto<>(HttpStatus.OK, result, "태그 개수 조회 성공");
     }
+
 }

--- a/src/main/java/com/book_everywhere/web/exception/customs/CustomErrorCode.java
+++ b/src/main/java/com/book_everywhere/web/exception/customs/CustomErrorCode.java
@@ -10,6 +10,7 @@ public enum CustomErrorCode {
     BOOK_NOT_FOUND(HttpStatus.NOT_FOUND, "BOOK NOT FOUND"),
     PIN_NOT_FOUND(HttpStatus.NOT_FOUND, "PIN NOT FOUND"),
     REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW NOT FOUND"),
+    TAG_NOT_FOUND(HttpStatus.NOT_FOUND, "TAG NOT FOUND"),
     ADDRESS_IS_NOT_NULL(HttpStatus.BAD_REQUEST, "주소는 공백이 될 수 없습니다."),
     BOOK_IS_NOT_NULL(HttpStatus.BAD_REQUEST, "책 정보는 공백이 될 수 없습니다."),
     TITLE_IS_NOT_BLANK(HttpStatus.BAD_REQUEST, "제목은 공백이 될 수 없습니다."),


### PR DESCRIPTION
visit, tagged 외래 키 오류
tags 값이 null일 경우 오류

독후감검증후책삭제,독후감검증후핀삭제에 book, pin null 분기처리를 추가합니다.

DataService 태그 조회를 pin과 유저를 통해 찾도록 변경합니다.