### PR TITLE
fix: JPA Redis Repository scan 문제 해결

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,6 +10,9 @@ spring:
     redis:
       repositories:
       enabled: false
+    jpa:
+      repositories:
+        bootstrap-mode: deferred
 
 server:
   env: blue


### PR DESCRIPTION
# Spring Data Redis , JPA 충돌문제

##  PR 체크리스트
- 생략

## 💡 관련 이슈
- [issue#180](https://github.com/SWYP-3-Reading-everywhere/readeve-BackEnd/issues/180)

## 💡 관련 PR
- [PR#179](https://github.com/SWYP-3-Reading-everywhere/readeve-BackEnd/pull/181)

## 해결 사항
`
    jpa:
      repositories:
        bootstrap-mode: deferred
`
추가